### PR TITLE
Fixed endianness bug in sml_number_init

### DIFF
--- a/sml/src/sml_number.c
+++ b/sml/src/sml_number.c
@@ -34,7 +34,7 @@ void *sml_number_init(u64 number, unsigned char type, int size) {
 	// Swap bytes of big-endian number so that
 	// memcpy copies the right part
 	if (sml_number_endian() == SML_BIG_ENDIAN) {
-		  sml_number_byte_swap(bytes, sizeof(u64));
+		  bytes += sizeof(u64) - size;
 	}
 
 	unsigned char *np = malloc(size);

--- a/sml/src/sml_number.c
+++ b/sml/src/sml_number.c
@@ -28,9 +28,18 @@ int sml_number_endian();
 void sml_number_byte_swap(unsigned char *bytes, int bytes_len);
 
 void *sml_number_init(u64 number, unsigned char type, int size) {
+	
+	unsigned char* bytes = (unsigned char*)&number;
+
+	// Swap bytes of big-endian number so that
+	// memcpy copies the right part
+	if (sml_number_endian() == SML_BIG_ENDIAN) {
+		  sml_number_byte_swap(bytes, sizeof(u64));
+	}
+
 	unsigned char *np = malloc(size);
 	memset(np, 0, size);
-	memcpy(np, &number, size);
+	memcpy(np, bytes, size);
 	return np;
 }
 


### PR DESCRIPTION
As discussed per mail, I provide the patch for the endianess problem in sml_number_init.

The solution in my mail was incorrect; the bytes in the u64 buffer do not need to be swapped, but the source pointer of memcpy needs to be incremented. I tested it on my router and it is fine now.

Regards
Daniel
